### PR TITLE
Add support for handling news article images in FileManager

### DIFF
--- a/src/Api/Forja.API/Controllers/Common/FilterDataController.cs
+++ b/src/Api/Forja.API/Controllers/Common/FilterDataController.cs
@@ -21,8 +21,8 @@ public class FilterDataController : ControllerBase
     /// This endpoint retrieves genres, mechanics, tags, and mature content details to be used in product filtering.
     /// </remarks>
     /// <returns>A collection of filter data.</returns>
-    [HttpGet("filters")]
-    public async Task<ActionResult<ProductsFilterDataDto>> GetGameFilterDataAsync()
+    [HttpGet("product-filters")]
+    public async Task<ActionResult<ProductsFilterDataDto>> GetProductFiltersDataAsync()
     {
         try
         {

--- a/src/Api/Forja.API/Controllers/Common/LegalDocumentController.cs
+++ b/src/Api/Forja.API/Controllers/Common/LegalDocumentController.cs
@@ -17,7 +17,6 @@ public class LegalDocumentController : ControllerBase
     /// <summary>
     /// Get a legal document by its ID.
     /// </summary>
-    [Authorize(Policy = "DocumentReadPolicy")]
     [HttpGet("{documentId:guid}")]
     public async Task<IActionResult> GetLegalDocumentById([FromRoute] Guid documentId)
     {
@@ -59,7 +58,7 @@ public class LegalDocumentController : ControllerBase
     /// <summary>
     /// Get legal documents by effective date.
     /// </summary>
-    [Authorize(Policy = "DocumentReadPolicy")]
+    [Authorize(Policy = "ContentManagePolicy")]
     [HttpGet("date")]
     public async Task<IActionResult> GetLegalDocumentsByEffectiveDate([FromQuery] DateTime? effectiveDate)
     {
@@ -99,7 +98,7 @@ public class LegalDocumentController : ControllerBase
     /// <summary>
     /// Get a legal document by its title.
     /// </summary>
-    [Authorize(Policy = "DocumentReadPolicy")]
+    [Authorize(Policy = "ContentManagePolicy")]
     [HttpGet("title")]
     public async Task<IActionResult> GetLegalDocumentByTitle([FromQuery] string title)
     {
@@ -141,7 +140,7 @@ public class LegalDocumentController : ControllerBase
     /// <summary>
     /// Create a new legal document.
     /// </summary>
-    [Authorize(Policy = "DocumentWritePolicy")]
+    [Authorize(Policy = "ContentManagePolicy")]
     [HttpPost]
     public async Task<IActionResult> CreateLegalDocument([FromBody] LegalDocumentCreateRequest request)
     {
@@ -182,7 +181,7 @@ public class LegalDocumentController : ControllerBase
     /// <summary>
     /// Update an existing legal document.
     /// </summary>
-    [Authorize(Policy = "DocumentWritePolicy")]
+    [Authorize(Policy = "ContentManagePolicy")]
     [HttpPut]
     public async Task<IActionResult> UpdateLegalDocument([FromBody] LegalDocumentUpdateRequest request)
     {
@@ -249,7 +248,7 @@ public class LegalDocumentController : ControllerBase
     /// <summary>
     /// Delete a legal document by its ID.
     /// </summary>
-    [Authorize(Policy = "DocumentWritePolicy")]
+    [Authorize(Policy = "ContentManagePolicy")]
     [HttpDelete("{documentId:guid}")]
     public async Task<IActionResult> DeleteLegalDocument([FromRoute] Guid documentId)
     {

--- a/src/Api/Forja.API/Controllers/Common/NewsArticleController.cs
+++ b/src/Api/Forja.API/Controllers/Common/NewsArticleController.cs
@@ -6,18 +6,20 @@ public class NewsArticleController : ControllerBase
 {
     private readonly INewsArticleService _newsArticleService;
     private readonly IAuditLogService _auditLogService;
+    private readonly IDistributedCache _cache;
 
     public NewsArticleController(INewsArticleService newsArticleService,
-        IAuditLogService auditLogService)
+        IAuditLogService auditLogService,
+        IDistributedCache cache)
     {
         _newsArticleService = newsArticleService;
         _auditLogService = auditLogService;
+        _cache = cache;
     }
     
     /// <summary>
     /// Get a news article by its ID.
     /// </summary>
-    [Authorize(Policy = "ArticleReadPolicy")]
     [HttpGet("{articleId:guid}")]
     public async Task<IActionResult> GetNewsArticleById([FromRoute] Guid articleId)
     {
@@ -59,7 +61,7 @@ public class NewsArticleController : ControllerBase
     /// <summary>
     /// Get news articles by publication date.
     /// </summary>
-    [Authorize(Policy = "ArticleReadPolicy")]
+    [Authorize(Policy = "ContentManagePolicy")]
     [HttpGet("date")]
     public async Task<IActionResult> GetNewsArticlesByPublicationDate([FromQuery] DateTime? publicationDate)
     {
@@ -99,14 +101,48 @@ public class NewsArticleController : ControllerBase
     /// <summary>
     /// Get active news articles.
     /// </summary>
-    [Authorize(Policy = "ArticleReadPolicy")]
     [HttpGet("active")]
-    public async Task<IActionResult> GetActiveNewsArticles()
+    public async Task<IActionResult> GetActiveNewsArticles(
+        [FromQuery] int pageNumber = 1,
+        [FromQuery] int pageSize = 10)
     {
         try
         {
-            var articles = await _newsArticleService.GetActiveNewsArticlesAsync();
-            return Ok(articles);
+            var cachedNewsArticles = await _cache.GetStringAsync("all_active_news_articles");
+            List<NewsArticleDto>? allNewsArticles;
+            if (!string.IsNullOrWhiteSpace(cachedNewsArticles))
+            {
+                allNewsArticles = JsonSerializer.Deserialize<List<NewsArticleDto>>(cachedNewsArticles);
+            }
+            else
+            {
+                allNewsArticles = await _newsArticleService.GetActiveNewsArticlesAsync();
+                if (!allNewsArticles.Any()) return NoContent();
+                
+                var serializedData = JsonSerializer.Serialize(allNewsArticles);
+
+                await _cache.SetStringAsync("all_active_news_articles", serializedData, new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30)
+                });
+            }
+            
+            if (allNewsArticles == null) return NoContent();
+            
+            var pagedArticles = allNewsArticles
+                .Skip((pageNumber - 1) * pageSize)
+                .Take(pageSize)
+                .ToList();
+
+            return Ok(new
+            {
+                PaginatedResult = new PaginatedResult<NewsArticleDto>(
+                    pagedArticles,
+                    allNewsArticles.Count,
+                    pageNumber,
+                    pageSize),
+                PrioritizedNewsArticles = allNewsArticles.Where(a => a.IsPrioritized)
+            });
         }
         catch (Exception ex)
         {
@@ -139,7 +175,7 @@ public class NewsArticleController : ControllerBase
     /// <summary>
     /// Create a new news article.
     /// </summary>
-    [Authorize(Policy = "ArticleWritePolicy")]
+    [Authorize(Policy = "ContentManagePolicy")]
     [HttpPost]
     public async Task<IActionResult> CreateNewsArticle([FromBody] NewsArticleCreateRequest request)
     {
@@ -180,7 +216,7 @@ public class NewsArticleController : ControllerBase
     /// <summary>
     /// Update an existing news article.
     /// </summary>
-    [Authorize(Policy = "ArticleWritePolicy")]
+    [Authorize(Policy = "ContentManagePolicy")]
     [HttpPut("{articleId:guid}")]
     public async Task<IActionResult> UpdateNewsArticle([FromRoute] Guid articleId, [FromBody] NewsArticleUpdateRequest request)
     {
@@ -247,7 +283,7 @@ public class NewsArticleController : ControllerBase
     /// <summary>
     /// Delete a news article by its ID.
     /// </summary>
-    [Authorize(Policy = "ArticleWritePolicy")]
+    [Authorize(Policy = "ContentManagePolicy")]
     [HttpDelete("{articleId:guid}")]
     public async Task<IActionResult> DeleteNewsArticle([FromRoute] Guid articleId)
     {

--- a/src/Api/Forja.API/Controllers/Storage/FilesController.cs
+++ b/src/Api/Forja.API/Controllers/Storage/FilesController.cs
@@ -498,6 +498,84 @@ public class FilesController : ControllerBase
     }
     
     [Authorize(Policy = "ContentManagePolicy")]
+    [HttpPost("news-article")]
+    public async Task<IActionResult> UploadNewsArticleImage([FromBody] UploadObjectImageRequest request)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+        try
+        {
+            var result = await _fileManagerService.UploadNewsArticleImageAsync(request);
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                var logEntry = new LogEntry<string>
+                {
+                    State = "Error",
+                    UserId = null,
+                    Exception = ex,
+                    ActionType = AuditActionType.ApiError,
+                    EntityType = AuditEntityType.Other,
+                    LogLevel = LogLevel.Error,
+                    Details = new Dictionary<string, string>
+                    {
+                        { "Message", "Failed to upload news article image." }
+                    }
+                };
+
+                await _auditLogService.LogWithLogEntryAsync(logEntry);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Error logging audit log entry: {e.Message}");
+            }
+            
+            return StatusCode(500, new { error = "An unexpected error occurred.", details = ex.Message });
+        }
+    }
+    
+    [Authorize(Policy = "ContentManagePolicy")]
+    [HttpDelete("news-article")]
+    public async Task<IActionResult> DeleteNewsArticleImageLogo([FromBody] DeleteObjectRequest request)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+        try
+        {
+            await _fileManagerService.DeleteNewsArticleImageAsync(request);
+            return NoContent();
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                var logEntry = new LogEntry<string>
+                {
+                    State = "Error",
+                    UserId = null,
+                    Exception = ex,
+                    ActionType = AuditActionType.ApiError,
+                    EntityType = AuditEntityType.Other,
+                    LogLevel = LogLevel.Error,
+                    Details = new Dictionary<string, string>
+                    {
+                        { "Message", "Failed to delete news article image." }
+                    }
+                };
+
+                await _auditLogService.LogWithLogEntryAsync(logEntry);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Error logging audit log entry: {e.Message}");
+            }
+            
+            return StatusCode(500, new { error = "An unexpected error occurred.", details = ex.Message });
+        }
+    }
+    
+    [Authorize(Policy = "ContentManagePolicy")]
     [HttpPost("mature-content-image")]
     public async Task<IActionResult> UploadMatureContentImage([FromBody] UploadObjectImageRequest request)
     {

--- a/src/Libraries/Forja.Application/DTOs/Common/ProductsFilterDataDto.cs
+++ b/src/Libraries/Forja.Application/DTOs/Common/ProductsFilterDataDto.cs
@@ -2,8 +2,8 @@ namespace Forja.Application.DTOs.Common;
 
 public class ProductsFilterDataDto
 {
-    public List<string> Genres { get; set; }
-    public List<string> Mechanics { get; set; }
-    public List<string> Tags { get; set; }
-    public List<string> MatureContents { get; set; }
+    public List<string> Genres { get; set; } = [];
+    public List<string> Mechanics { get; set; } = [];
+    public List<string> Tags { get; set; } = [];
+    public List<string> MatureContents { get; set; } = [];
 }

--- a/src/Libraries/Forja.Application/Interfaces/Common/INewsArticleService.cs
+++ b/src/Libraries/Forja.Application/Interfaces/Common/INewsArticleService.cs
@@ -18,13 +18,13 @@ public interface INewsArticleService
     /// </summary>
     /// <param name="publicationDate">The publication date to filter the articles. If null, retrieves all articles.</param>
     /// <returns>A task representing the asynchronous operation. The task result contains an IEnumerable of NewsArticleDto, representing the filtered news articles.</returns>
-    Task<IEnumerable<NewsArticleDto>> GetNewsArticlesByPublicationDateAsync(DateTime? publicationDate = null);
+    Task<List<NewsArticleDto>> GetNewsArticlesByPublicationDateAsync(DateTime? publicationDate = null);
 
     /// <summary>
     /// Retrieves a collection of active news articles.
     /// </summary>
     /// <returns>A task that represents the asynchronous operation. The task result contains a collection of active news articles.</returns>
-    Task<IEnumerable<NewsArticleDto>> GetActiveNewsArticlesAsync();
+    Task<List<NewsArticleDto>> GetActiveNewsArticlesAsync();
 
     /// <summary>
     /// Creates a new News Article with the specified details and returns the created article.

--- a/src/Libraries/Forja.Application/Interfaces/Storage/IFileManagerService.cs
+++ b/src/Libraries/Forja.Application/Interfaces/Storage/IFileManagerService.cs
@@ -38,6 +38,10 @@ public interface IFileManagerService
     Task<string> UploadMechanicImageAsync(UploadObjectImageRequest request);
 
     Task DeleteMechanicImageAsync(DeleteObjectRequest request);
+    
+    Task<string> UploadNewsArticleImageAsync(UploadObjectImageRequest request);
+
+    Task DeleteNewsArticleImageAsync(DeleteObjectRequest request);
 
     Task<string> GetPresignedUrlAsync(string objectPath, int expiresInSeconds = 3600);
 
@@ -53,4 +57,5 @@ public interface IFileManagerService
     Task<string> GetPresignedAchievementImageUrlAsync(Guid achievementId, int expiresInSeconds = 3600);
     Task<string> GetPresignedMatureContentImageUrlAsync(Guid matureContentId, int expiresInSeconds = 3600);
     Task<string> GetPresignedMechanicImageUrlAsync(Guid mechanicId, int expiresInSeconds = 3600);
+    Task<string> GetPresignedNewsArticleImageUrlAsync(Guid mechanicId, int expiresInSeconds = 3600);
 }

--- a/src/Libraries/Forja.Application/Mapping/CommonEntityToDtoMapper.cs
+++ b/src/Libraries/Forja.Application/Mapping/CommonEntityToDtoMapper.cs
@@ -16,7 +16,7 @@ public static class CommonEntityToDtoMapper
         };
     }
 
-    public static NewsArticleDto MapToNewsArticleDto(NewsArticle entity)
+    public static NewsArticleDto MapToNewsArticleDto(NewsArticle entity, string fullImageUrl)
     {
         return new NewsArticleDto
         {
@@ -28,7 +28,7 @@ public static class CommonEntityToDtoMapper
             IsPrioritized = entity.IsPrioritized,
             CreatedAt = entity.CreatedAt,
             FileContent = entity.FileContent,
-            ImageUrl = entity.ImageUrl,
+            ImageUrl = fullImageUrl,
             AuthorId = entity.AuthorId,
             ProductId = entity.ProductId
         };


### PR DESCRIPTION
Introduced methods to upload, delete, and generate presigned URLs for news article images in `IFileManagerService` and `FileManagerService`. Updated `NewsArticleService` to include presigned image URLs in responses and implemented caching for active news articles in `NewsArticleController`. Additionally, standardized DTO initialization and adjusted policies in controllers for consistency.